### PR TITLE
#99 Include missing JDK11 deps in zip

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,19 +340,16 @@
                     <groupId>javax.activation</groupId>
                     <artifactId>javax.activation-api</artifactId>
                     <version>1.2.0</version>
-                    <scope>provided</scope>
                 </dependency>
                 <dependency>
                     <groupId>javax.xml.bind</groupId>
                     <artifactId>jaxb-api</artifactId>
                     <version>2.4.0-b180830.0359</version>
-                    <scope>provided</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.glassfish.jaxb</groupId>
                     <artifactId>jaxb-runtime</artifactId>
                     <version>2.4.0-b180830.0438</version>
-                    <scope>provided</scope>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
Executing JWSACruncher v2.2.3 with Java 11 leads to the following exception (due to JAXB removal in Java 11):

```
Exception in thread "main" java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException
	at ec.jwsacruncher.App.generateDefaultConfigFile(App.java:95)
	at ec.jwsacruncher.App.main(App.java:72)
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.JAXBException
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 2 more
```
